### PR TITLE
Portuguese Broa Bread Recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Custom recipes:
 * [Standard bread](recipes/standard-bread.md)
 * [French bread](recipes/french-bread.md)
 * [Date walnut bread](recipes/date-walnut-bread.md)
+* [Portuguese inspired Broa corn bread](recipes/portuguese-broa-corn-bread.md)
 * [Line seeds bread](recipes/lineseeds-bread.md)
 * [Bacon bread](recipes/bacon-bread.md)
 * [Salami bread](recipes/salami-bread.md)

--- a/recipes/portuguese-broa-corn-bread.md
+++ b/recipes/portuguese-broa-corn-bread.md
@@ -1,0 +1,14 @@
+# Portuguese inspired Broa Corn Bread
+
+Broa is a type of corn and rye/wheat bread traditionally made in Portugal, Galicia, Angola, Mozambique, Cape Verde, and Brazil. Unlike the cornbread typical of the southern United States, broa is made from a mixture of cornmeal and rye or wheat flour, and is leavened with yeast.
+
+When baking with corn you need to deploy different strategies. Corn flour for instance has no Gluten. As a consequence the whole dough will not stick together as nicely as regular wheat dough. At the same time the bread is a little more dense as not as much air can be trapped inside of the dough when baking.
+
+This recipe is only an inspired broa bread as I used 30% corn flour and 70% wheat flour. Originally there would be a higher percentage of corn meal. However that way you enjoy the fluffy interior from wheat as well as the slight corn taste. To me this strategy is a great combination of the best out of two worlds, corn bread and wheat bread.
+
+![Portuguese Broa Bread](https://i.imgur.com/KBuOAxg.png)
+
+## Custom Ingredients
+
+- 350 grams of all purpose flour instead of 500
+- 150 grams of corn flour


### PR DESCRIPTION
Broa is a type of corn and rye/wheat bread traditionally made in Portugal, Galicia, Angola, Mozambique, Cape Verde, and Brazil. Unlike the cornbread typical of the southern United States, broa is made from a mixture of cornmeal and rye or wheat flour, and is leavened with yeast.