### PR TITLE
Add note that also strong flour can be used

### DIFF
--- a/basics/basic-sour-dough.md
+++ b/basics/basic-sour-dough.md
@@ -37,7 +37,7 @@ for an actual recipe you can bake.
 
 ## Ingredients
 
-- 500 grams of all-purpose flour (high protein). In Germany type 550.
+- 500 grams of all-purpose flour. In Germany type 550. You can also use strong flour but working the dough becomes a little more difficult. The dough will be stickier. Thus for beginners go with all purpose flour.
 - 325 grams of water or 65%. Experiment with more hydration as well.
 - 200 grams or 40% of sourdough starter at 100% hydration.
 - 14  grams of salt or 2%.


### PR DESCRIPTION
Added a note that you can also use strong flour on the basic sour dough
recipe. Also explained that the dough will be more sticky and thus
harder to work. Especially during shaping the dough will stick to your
hands more.