### PR TITLE
Add a note that some ingredients should be excluded

### DIFF
--- a/basics/basic-dough.md
+++ b/basics/basic-dough.md
@@ -24,7 +24,10 @@ Custom recipes hook in here with additional steps that are required to be done b
 
 ### Autolyse
 
-Mix together all the ingredients in a large bowl except the yeast. Stir them with a spoon for 2 minutes.
+Mix together all the ingredients listed by the recipe. Some recipes require
+you to exclude ingredients initially. Instead they will be added later during
+the shaping phase. Proceed and all the ingredients in large bowl in front of you.
+Stir them with a spoon for 2 minutes.
 Let the dough rest for an hour after this step to have the flour absorb the water.
 Furthermore the atoms will homogenize and spread evenly throughout the dough.
 

--- a/recipes/savory/bacon-bread.md
+++ b/recipes/savory/bacon-bread.md
@@ -8,7 +8,7 @@ This bread is excellent when inviting friends over for a barbecue.
 
 ## Custom Ingredients
 
-- 100 grams of bacon
+- 100 grams of bacon. Add Recipe Customization phase.
 
 ### Pre steps
 


### PR DESCRIPTION
In some recipes we exclude the ingredients. This is because we do not
want the ingredients to influence the dough too much. Instead we add the
ingredients before the final shaping.

In case you want to make sure the ingredients are fully homogenized you
can add them right away initially. However that mightinfluence the way
how you have to handle the dough.