### PR TITLE
Setup Recipe Parser

### DIFF
--- a/lib/recipe_parser/.gitignore
+++ b/lib/recipe_parser/.gitignore
@@ -1,0 +1,11 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/lib/recipe_parser/.rspec
+++ b/lib/recipe_parser/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/lib/recipe_parser/.travis.yml
+++ b/lib/recipe_parser/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: ruby
+rvm:
+  - 2.4.2
+before_install: gem install bundler -v 1.16.0

--- a/lib/recipe_parser/Gemfile
+++ b/lib/recipe_parser/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in recipe_parser.gemspec
+gemspec

--- a/lib/recipe_parser/Gemfile.lock
+++ b/lib/recipe_parser/Gemfile.lock
@@ -1,0 +1,43 @@
+PATH
+  remote: .
+  specs:
+    recipe_parser (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.2)
+    diff-lcs (1.3)
+    method_source (0.9.0)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    rake (10.5.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+    slop (3.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.16)
+  pry (~> 0.9.12.2)
+  rake (~> 10.0)
+  recipe_parser!
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   1.16.0

--- a/lib/recipe_parser/README.md
+++ b/lib/recipe_parser/README.md
@@ -1,0 +1,44 @@
+# Recipe Parser
+
+Since our templates inherit from each other we need to understand the
+content of each of the templates. My long term vision is to create a
+user friendly version in which all the templates are properly merged
+together. Then you can just read one of the recipes. It will be
+automatically added in the proper template.
+
+At the same time I still want markdown to be used for all the recipes.
+That makes it very comfortable to write recipes. At the same time it is
+also a little easier for everyone to follow the recipes directly in this
+git repository.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'recipe_parser'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install recipe_parser
+
+## Usage
+
+Currently only tests have been added.
+
+```
+bundle exec rspec
+```
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).

--- a/lib/recipe_parser/Rakefile
+++ b/lib/recipe_parser/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/lib/recipe_parser/bin/console
+++ b/lib/recipe_parser/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "recipe_parser"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/lib/recipe_parser/bin/setup
+++ b/lib/recipe_parser/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/recipe_parser/lib/recipe_parser.rb
+++ b/lib/recipe_parser/lib/recipe_parser.rb
@@ -1,0 +1,7 @@
+require "recipe_parser/version"
+require "recipe_parser/sections_extractor"
+require "recipe_parser/section"
+
+module RecipeParser
+  # Your code goes here...
+end

--- a/lib/recipe_parser/lib/recipe_parser/section.rb
+++ b/lib/recipe_parser/lib/recipe_parser/section.rb
@@ -1,0 +1,17 @@
+require "recipe_parser"
+
+module RecipeParser
+  class Section
+    DEFAULT     = :section.freeze
+    INGREDIENTS = :ingredients.freeze
+    TITLE       = :title.freeze
+
+    attr_reader :name, :content, :type
+
+    def initialize(name:, content:, type: :section)
+      @name    = name
+      @content = content
+      @type    = type
+    end
+  end
+end

--- a/lib/recipe_parser/lib/recipe_parser/sections_extractor.rb
+++ b/lib/recipe_parser/lib/recipe_parser/sections_extractor.rb
@@ -1,0 +1,45 @@
+require "recipe_parser"
+
+module RecipeParser
+  class SectionsExtractor
+    def initialize(markdown)
+      @markdown = markdown
+    end
+
+    def sections
+      @sections ||= parse_sections
+    end
+
+    private
+
+    def parse_sections
+      return [] if @markdown&.empty?
+      matches = @markdown.scan(regex)
+      return [] if matches.nil?
+      convert_matches(matches)
+    end
+
+    def convert_matches(matches)
+      matches.each_with_index.map do |group, index|
+        group = group.map {|g| g.strip }
+        Section.new(
+          name: group[1],
+          content: group[2],
+          type: extract_type(name: group[1],
+                             position: index + 1,
+                             total_sections: matches.length)
+        )
+      end
+    end
+
+    def extract_type(name:, position:, total_sections:)
+      return Section::TITLE if position == 1
+      return Section::INGREDIENTS if name == "Ingredients"
+      Section::DEFAULT
+    end
+
+    def regex
+      /^(\#{1,})\s(.*$)([\s\S]*?)(?=#|\Z)/
+    end
+  end
+end

--- a/lib/recipe_parser/lib/recipe_parser/version.rb
+++ b/lib/recipe_parser/lib/recipe_parser/version.rb
@@ -1,0 +1,3 @@
+module RecipeParser
+  VERSION = "0.1.0"
+end

--- a/lib/recipe_parser/recipe_parser.gemspec
+++ b/lib/recipe_parser/recipe_parser.gemspec
@@ -1,0 +1,36 @@
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "recipe_parser/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "recipe_parser"
+  spec.version       = RecipeParser::VERSION
+  spec.authors       = ["Hendrik Kleinwaechter"]
+  spec.email         = ["hendrik.kleinwaechter@gmail.com"]
+
+  spec.summary       = %q{Parse Bread Code Recipes}
+  spec.description   = %q{Parse Bread Code Recipes}
+  spec.homepage      = "https://github.com/hendricius/the-bread-code"
+
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against " \
+      "public gem pushes."
+  end
+
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry", '~> 0.9.12.2'
+end

--- a/lib/recipe_parser/spec/fixtures/sourdough_standard_recipe.md
+++ b/lib/recipe_parser/spec/fixtures/sourdough_standard_recipe.md
@@ -1,0 +1,1 @@
+../../../../basics/basic-sour-dough.md

--- a/lib/recipe_parser/spec/fixtures/standard_recipe.md
+++ b/lib/recipe_parser/spec/fixtures/standard_recipe.md
@@ -1,0 +1,1 @@
+../../../../basics/basic-dough.md

--- a/lib/recipe_parser/spec/recipe_parser_spec.rb
+++ b/lib/recipe_parser/spec/recipe_parser_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe RecipeParser do
+  it "has a version number" do
+    expect(RecipeParser::VERSION).not_to be nil
+  end
+end

--- a/lib/recipe_parser/spec/sections_extractor_spec.rb
+++ b/lib/recipe_parser/spec/sections_extractor_spec.rb
@@ -1,0 +1,89 @@
+RSpec.describe RecipeParser::SectionsExtractor do
+
+  describe "basic" do
+    it "can be instantiated" do
+      expect(described_class.new("").class).to eq(described_class)
+    end
+  end
+
+  describe ".sections" do
+    let(:sample_recipe) { File.read("#{Dir.pwd}/spec/fixtures/standard_recipe.md")}
+    let(:sample_sourdough_recipe) { File.read("#{Dir.pwd}/spec/fixtures/sourdough_standard_recipe.md")}
+    let(:service) { described_class.new(sample_recipe) }
+    let(:sourdough_service) { described_class.new(sample_sourdough_recipe) }
+
+    it "returns the correct amount of sections" do
+      expect(service.sections.length).to eq(16)
+    end
+
+    it "has the title properly extracted" do
+      sect = service.sections.first
+      expect(sect.name).to eq('The Basic Dough')
+      expect(sect.type).to eq(:title)
+    end
+
+    it "has the ingredients properly extracted" do
+      sect = service.sections[1]
+      expect(sect.name).to eq('Ingredients')
+      expect(sect.type).to eq(:ingredients)
+    end
+
+    it "has the correct last section" do
+      sect = service.sections.last
+      expect(sect.name).to eq('Remove (the tray with water or lid)')
+      expect(sect.type).to eq(:section)
+    end
+
+    it "has all the headlines in order" do
+      expected = [
+        "The Basic Dough",
+        "Ingredients",
+        "Instructions",
+        "Preparation steps",
+        "Autolyse",
+        "Add the yeast",
+        "Form the gluten",
+        "Stretch and Fold Part 1",
+        "Stretch and Fold Part 2",
+        "Shaping the dough",
+        "Recipe customization",
+        "Finalizing the shaping",
+        "Place the dough in a clean bowl",
+        "Preheat the oven to maximum temperature",
+        "Finally bake the bread",
+        "Remove (the tray with water or lid)",
+      ]
+      sections = service.sections
+      expected.each_with_index do |exp, index|
+        expect(sections[index]).to_not be_nil
+        expect(sections[index].name).to eq(exp)
+      end
+    end
+
+    it "extracts sections for the sourdough template too" do
+      expected = [
+        "The Basic Sourdough",
+        "Ingredients",
+        "Instructions",
+        "Preparation steps",
+        "Autolyse",
+        "Add the starter dough",
+        "Give back to the mother dough",
+        "Knead the dough",
+        "Let the gluten form",
+        "Shape the dough",
+        "Recipe customization",
+        "Finalizing the shaping",
+        "Place the dough in a clean bowl",
+        "Preheat the oven to maximum temperature",
+        "Finally bake the bread",
+        "Remove (the tray with water or lid)"
+      ]
+      sections = sourdough_service.sections
+      expected.each_with_index do |exp, index|
+        expect(sections[index]).to_not be_nil
+        expect(sections[index].name).to eq(exp)
+      end
+    end
+  end
+end

--- a/lib/recipe_parser/spec/spec_helper.rb
+++ b/lib/recipe_parser/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+require "bundler/setup"
+require "pry"
+require "recipe_parser"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
Since our templates inherit from each other we need to understand the
content of each of the templates. My long term vision is to create a
user friendly version in which all the templates are properly merged
together. Then you can just read one of the recipes. It will be
automatically added in the proper template.

Then you can read all the instructions together in one place.

At the same time I still want markdown to be used for all the recipes.
That makes it very comfortable to write recipes. At the same time it is
also a little easier for everyone to follow the recipes directly in this
git repository.